### PR TITLE
Split run() into smaller methods

### DIFF
--- a/src/DumpRuntime.php
+++ b/src/DumpRuntime.php
@@ -37,7 +37,7 @@ final class DumpRuntime
         $result = [];
 
         foreach ($packages as $i => $package) {
-            $this->loadConfigPackage($result, $i, $package);
+            $result = $this->loadConfigPackage($result, $i, $package);
         }
 
         return $result;
@@ -45,13 +45,15 @@ final class DumpRuntime
 
     /**
      * @param array<string, list<string>> $result
+     *
+     * @return array<string, list<string>>
      */
-    private function loadConfigPackage(array &$result, int $i, PackageInterface $package): void
+    private function loadConfigPackage(array $result, int $i, PackageInterface $package): array
     {
         $extra = $package->getExtra();
 
         if (!isset($extra['phel'])) {
-            return;
+            return $result;
         }
 
         // First package is the current project (no dependency)
@@ -66,15 +68,19 @@ final class DumpRuntime
             if (!isset($phelConfig[$loaderName])) {
                 continue;
             }
-            $this->loadConfigNames($result, $phelConfig[$loaderName], $pathPrefix);
+            $result = $this->loadConfigNames($result, $phelConfig[$loaderName], $pathPrefix);
         }
+
+        return $result;
     }
 
     /**
      * @param array<string, list<string>> $result
      * @param array<string, string|list<string>> $packageLoadConfig
+     *
+     * @return array<string, list<string>>
      */
-    private function loadConfigNames(array &$result, array $packageLoadConfig, string $pathPrefix): void
+    private function loadConfigNames(array $result, array $packageLoadConfig, string $pathPrefix): array
     {
         foreach ($packageLoadConfig as $ns => $pathList) {
             if (!isset($result[$ns])) {
@@ -89,6 +95,8 @@ final class DumpRuntime
                 $result[$ns][] = $pathPrefix . '/' . $path;
             }
         }
+
+        return $result;
     }
 
     /**

--- a/src/DumpRuntime.php
+++ b/src/DumpRuntime.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Phel\Composer;
 
 use Composer\Composer;
-use Composer\Package\Package;
+use Composer\Package\PackageInterface;
 
 final class DumpRuntime
 {
@@ -17,7 +17,7 @@ final class DumpRuntime
             ...$composer->getLocker()->getLockedRepository()->getPackages(),
         ];
 
-        /** @var list<Package> $packages */
+        /** @var list<PackageInterface> $packages */
         $loadedConfig = $this->loadConfig($packages);
 
         /** @var string $vendorDir */
@@ -27,7 +27,7 @@ final class DumpRuntime
     }
 
     /**
-     * @param list<Package> $packages
+     * @param list<PackageInterface> $packages
      *
      * @return array<string, list<string>>
      */
@@ -46,7 +46,7 @@ final class DumpRuntime
     /**
      * @param array<string, list<string>> $result
      */
-    private function loadConfigPackage(array &$result, int $i, Package $package): void
+    private function loadConfigPackage(array &$result, int $i, PackageInterface $package): void
     {
         $extra = $package->getExtra();
 
@@ -92,7 +92,7 @@ final class DumpRuntime
     }
 
     /**
-     * @param array<string, array<string>> $loadConfig
+     * @param array<string, list<string>> $loadConfig
      */
     private function createRuntimeScript(array $loadConfig): string
     {

--- a/src/DumpRuntime.php
+++ b/src/DumpRuntime.php
@@ -56,18 +56,13 @@ final class DumpRuntime
             return $result;
         }
 
+        /** @var array<string,array<string, string|list<string>>> $phelConfig */
+        $phelConfig = $extra['phel'];
         // First package is the current project (no dependency)
         $isRootPackage = ($i === 0);
         $pathPrefix = $isRootPackage ? '/..' : '/' . $package->getName();
-        $loaderNames = $isRootPackage ? ['loader', 'loader-dev'] : ['loader'];
 
-        /** @var array<string,array<string, string|list<string>>> $phelConfig */
-        $phelConfig = $extra['phel'];
-
-        foreach ($loaderNames as $loaderName) {
-            if (!isset($phelConfig[$loaderName])) {
-                continue;
-            }
+        foreach ($this->loaderNames($isRootPackage, $phelConfig) as $loaderName) {
             $result = $this->loadConfigNames($result, $phelConfig[$loaderName], $pathPrefix);
         }
 
@@ -126,5 +121,23 @@ EOF;
         $template .= "return \$rt;\n";
 
         return $template;
+    }
+
+    /**
+     * @param bool $isRootPackage First package is the current project (no dependency)
+     * @param array<string,array<string, string|list<string>>> $phelConfig
+     *
+     * @return list<string>
+     */
+    private function loaderNames(bool $isRootPackage, array $phelConfig): array
+    {
+        $loaderNames = $isRootPackage ? ['loader', 'loader-dev'] : ['loader'];
+
+        $loaderNames = array_filter(
+            $loaderNames,
+            static fn ($loaderName) => isset($phelConfig[$loaderName])
+        );
+
+        return array_values($loaderNames);
     }
 }


### PR DESCRIPTION
I didn't change the existing logic. I just split the big method into smaller ones to understand better the flow of it.